### PR TITLE
不再根据文件大小判断是视频还是音频,根据结尾是否为30280.m4s判断更准确,同时兼容原有判断

### DIFF
--- a/modules/utils/FileUtils.py
+++ b/modules/utils/FileUtils.py
@@ -62,12 +62,18 @@ class FileUtils:
 
     @staticmethod
     def compareFileSize(file1, file2):
-        size1 = os.path.getsize(file1)
-        size2 = os.path.getsize(file2)
-
-        if size1 > size2:
+        # 如果第2个文件是音频,返回true
+        if file2.endswith("30280.m4s"):
             return True
-        elif size1 < size2:
+        # 如果第1个文件是音频,返回false
+        elif file1.endswith("30280.m4s"):
             return False
         else:
-            return False
+            size1 = os.path.getsize(file1)
+            size2 = os.path.getsize(file2)
+            if size1 > size2:
+                return True
+            elif size1 < size2:
+                return False
+            else:
+                return False


### PR DESCRIPTION
目前bilibili出了自己的客户端,可以通过客户端快速缓存视频,缓存文件有一个规律,30280.m4s结尾的必然是音频